### PR TITLE
fix(error): If there is an error in the UIView, catch error in an boundary and just return null

### DIFF
--- a/example/src/ReactComponent.js
+++ b/example/src/ReactComponent.js
@@ -3,13 +3,14 @@ import { UIView } from '@uirouter/react';
 
 export class ReactComponent extends Component {
   render() {
+    const makeReactCptFail = { x: 3, y: 4 };
     return (
       <div>
         <h1>Hello from react</h1>
-        <h3>{this.props.$state$.name} state loaded</h3> 
-
-        <UIView/>
+        <h3>{this.props.$state$.name} state loaded</h3>
+        {makeReactCptFail}
+        <UIView />
       </div>
     );
   }
-};
+}

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+export interface ErrorBoundaryProps {}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, any> {
+  state = { error: null };
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ error, errorInfo });
+  }
+
+  render() {
+    if (this.state.error) {
+      return null;
+    }
+    return this.props.children;
+  }
+}

--- a/src/angularjs/ReactUIViewAdapterComponent.tsx
+++ b/src/angularjs/ReactUIViewAdapterComponent.tsx
@@ -5,6 +5,7 @@ import { hybridModule } from './module';
 import { UIView, UIViewProps } from '@uirouter/react';
 import { filter } from '@uirouter/core';
 import { UIRouterContextComponent } from '../react/UIRouterReactContext';
+import { ErrorBoundary } from '../ErrorBoundary';
 
 // When an angularjs `ui-view` is instantiated, also create an adapter (which creates a react UIView)
 hybridModule.directive('uiView', function() {
@@ -99,6 +100,8 @@ hybridModule.directive('reactUiViewAdapter', function() {
 
 const ReactUIView = ({ refFn, ...props }) => (
   <UIRouterContextComponent parentContextLevel="3">
-    <UIView {...props} ref={refFn} />
+    <ErrorBoundary>
+      <UIView {...props} ref={refFn} />
+    </ErrorBoundary>
   </UIRouterContextComponent>
 );


### PR DESCRIPTION
… error

This fixes the problem by keeping state that the UIRouterContextComponent went into an error state, and for some reason there needs be an ErrorBoundary component wrapped around UiView, otherwise it just spits out 621 errors.

Closes #33 