### PR TITLE
Bugfix - `.remove()` not defined in IE11

### DIFF
--- a/src/angularjs/ReactUIViewAdapterComponent.tsx
+++ b/src/angularjs/ReactUIViewAdapterComponent.tsx
@@ -90,7 +90,8 @@ hybridModule.directive('reactUiViewAdapter', function() {
         destroyed = true;
         const unmounted = ReactDOM.unmountComponentAtNode(el);
         // console.log(`${$id}: angular $destroy event -- unmountComponentAtNode(): ${unmounted}`, el);
-        el.remove();
+        // Remove using jQLite element for cross-browser compatibility.
+        elem.remove();
       });
 
       renderReactUIView();


### PR DESCRIPTION
While this is not a terribly breaking things, it doesn't clean up after itself properly.

As can be seen in https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove#Browser_compatibility, IE does not support this method. Using jQLite `.remove()` method fixes this problem.

Here's the screenshot of the error stack:
<img width="409" alt="screen shot 2018-08-23 at 10 27 09 am" src="https://user-images.githubusercontent.com/1277553/44512357-e889a080-a6c2-11e8-89ae-55ddec41acfa.png">
