### PR TITLE
Bugfix - Infinite loop in AngularJS -> React portal

### DIFF
--- a/src/angularjs/ReactUIViewAdapterComponent.tsx
+++ b/src/angularjs/ReactUIViewAdapterComponent.tsx
@@ -45,7 +45,15 @@ hybridModule.directive('reactUiViewAdapter', function() {
 
       // The UIView ref callback, which is called after the initial render
       const ref = ref => {
-        if (ref && _ref === ref) return;
+        if (
+          // If refs are the same - don't re-render React component.
+          (ref && _ref === ref) ||
+          // If previously there was a ref, and the new `ref` is empty - the component was unmounted.
+          // Leave the unmounted component as it was, and don't try to re-mount it.
+          (!ref && _ref)
+        ) {
+          return;
+        }
         _ref = ref;
 
         // log(`${$id}: received new React UIView ref:`, ref);


### PR DESCRIPTION
This is a simple fix to prevent `reactUiViewAdapter` directive from re-rendering the child React component if it was unmounted _after_ it was originally mounted.

By doing so, we ensure that:

- Child component is able to un-mount itself (if it needs to, for some reason).
- Any error in child component will not cause it to be removed from DOM (resulting in ref callback being called with `null`), and then added back again, just to error out again.

The 2nd case is important here - normally we could do this with an error boundary (as it's done in #34), however this has added benefit to also support the 1st point of component being able to de-render itself. This, in my eyes, creates less assumptions about how component will be rendered, thus delegating it more control.