### PR TITLE
Use ReactDOM.createPortal instead of ReactDOM.render for nested views

### DIFF
--- a/src/react/AngularUIView.tsx
+++ b/src/react/AngularUIView.tsx
@@ -22,6 +22,8 @@ export class AngularUIView extends React.Component<any, any> {
     this.state = {
       $scope: $rootScope.$new(),
     };
+
+    this.state.$scope.setChildViewProps = this.props.setChildViewProps;
   }
 
   render() {

--- a/src/react/ReactUIView.tsx
+++ b/src/react/ReactUIView.tsx
@@ -1,0 +1,19 @@
+import { UIRouterConsumer, UIView, UIViewConsumer } from "@uirouter/react";
+import { UIRouterContextComponent } from "./UIRouterReactContext";
+import * as React from "react";
+
+const InternalUIView = UIView.__internalViewComponent;
+
+const ReactUIView = ({ refFn, ...props }) => (
+  <UIRouterContextComponent parentContextLevel="3" inherited={false}>
+    <UIRouterConsumer>
+      {router => (
+        <UIViewConsumer>
+          {parentUiView => <InternalUIView {...props} ref={refFn} parentUIView={parentUiView} router={router} />}
+        </UIViewConsumer>
+      )}
+    </UIRouterConsumer>
+  </UIRouterContextComponent>
+);
+
+export default ReactUIView;

--- a/src/react/UIRouterReactContext.tsx
+++ b/src/react/UIRouterReactContext.tsx
@@ -7,6 +7,7 @@ import IInjectorService = angular.auto.IInjectorService;
 
 export interface IUIRouterContextComponentProps {
   parentContextLevel?: string;
+  inherited?: boolean;
 }
 
 export interface IUIRouterContextComponentState {
@@ -27,6 +28,7 @@ export class UIRouterContextComponent extends React.Component<
 > {
   public static defaultProps: Partial<IUIRouterContextComponentProps> = {
     parentContextLevel: '0',
+    inherited: true,
   };
 
   public state: IUIRouterContextComponentState = {
@@ -71,13 +73,14 @@ export class UIRouterContextComponent extends React.Component<
 
   private renderChild(child: ReactElement<any>) {
     // console.log('renderChild()', child);
+    const inherited = this.props.inherited;
     return (
       <UIRouterConsumer>
         {routerFromReactContext => (
-          <UIRouterProvider value={routerFromReactContext || this.state.router}>
+          <UIRouterProvider value={inherited && routerFromReactContext || this.state.router}>
             <UIViewConsumer>
               {parentUIViewFromReactContext => (
-                <UIViewProvider value={parentUIViewFromReactContext || this.state.parentUIViewAddress}>
+                <UIViewProvider value={inherited && parentUIViewFromReactContext || this.state.parentUIViewAddress}>
                   {child}
                 </UIViewProvider>
               )}

--- a/src/react/UIViewMonkeyPatch.tsx
+++ b/src/react/UIViewMonkeyPatch.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { UIView } from '@uirouter/react';
 import { AngularUIView } from './AngularUIView';
+import ReactUIView from "./ReactUIView";
 
 /**
  * Monkey patches the @uirouter/react UIView such that:
@@ -20,10 +22,44 @@ import { AngularUIView } from './AngularUIView';
  */
 const realRender = UIView.prototype.render;
 
+class PortalView extends React.PureComponent {
+  state = {
+    props: null,
+    target: null,
+  };
+
+  setChildViewProps = (props, target) => {
+    this.setState({ props, target });
+  };
+
+  renderPortal() {
+    if (!this.state) return null;
+    const { props, target } = this.state;
+    if (props && target) {
+      return ReactDOM.createPortal(
+        <ReactUIView {...props} />,
+        target
+      );
+    }
+    return null;
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <AngularUIView {...this.props} setChildViewProps={this.setChildViewProps}/>
+        {this.renderPortal()}
+      </React.Fragment>
+    )
+  }
+}
+
 UIView.prototype.render = function() {
   if (this.props.wrap === false) {
     return realRender.apply(this, arguments);
   }
 
-  return <AngularUIView {...this.props} />;
+  return (
+    <PortalView {...this.props}/>
+  );
 };


### PR DESCRIPTION
I've noticed that each react view is rendered as a separate React instance. As a result, it's impossible to share react context between views. In this PR I have tried to fix this behavior by using react portals.

@christopherthielen, what do you think about that?