### PR TITLE
Add Suport for componentProvider

### DIFF
--- a/src/decorateUIRouterViewConfigs.ts
+++ b/src/decorateUIRouterViewConfigs.ts
@@ -31,9 +31,37 @@ hybridModule.config([
 
       Object.keys(views).forEach(key => {
         const view = views[key];
-        const selfView = selfViews[key || '$default'];
-        const reactType = isReactComponent(view.component) && 'react';
-        view.$type = selfViews[key].$type || reactType || view.$type;
+        if (view.componentProvider) {
+          // If view component provider is given, monkey-patch the type in runtime.
+          const injectables = [...view.componentProvider];
+          // Remove the runner function, and just leave `injectables` with deps.
+          const func = injectables.pop();
+
+          // Create a new component provider.
+          view.componentProvider = [
+            // Original injectables.
+            ...injectables,
+            (...args) => {
+              // Get the component declaration.
+              const cmp = func(...args);
+              // Determine if it's react.
+              var reactType = isReactComponent(cmp) && 'react';
+              view.$type = selfViews[key].$type || reactType || view.$type;
+
+              if (view.$type === 'react') {
+                // Set the component, if it's react, as `ReactViewConfig` expects the `component`
+                // property.
+                view.component = cmp;
+              }
+              // Also return component for AngularjS components.
+              return cmp;
+            },
+          ];
+        } else {
+          var selfView = selfViews[key || '$default'];
+          var reactType = isReactComponent(view.component) && 'react';
+          view.$type = selfViews[key].$type || reactType || view.$type;
+        }
       });
 
       return views;


### PR DESCRIPTION
Adds support for `componentProvider` feature that angularJS's version of router has. It will hijack the property, attaches its own provider and then updates the `component` definition from that.