### PR TITLE
feat(*): Allow React functional components

### DIFF
--- a/src/decorateUIRouterViewConfigs.ts
+++ b/src/decorateUIRouterViewConfigs.ts
@@ -27,7 +27,8 @@ hybridModule.config([
       const isReactComponent = cmp =>
         cmp instanceof React.Component ||
         (cmp && cmp.prototype && cmp.prototype.isReactComponent) ||
-        (cmp && cmp.prototype && typeof cmp.prototype.render === 'function');
+        (cmp && cmp.prototype && typeof cmp.prototype.render === 'function') ||
+        (cmp && typeof cmp === 'function');
 
       Object.keys(views).forEach(key => {
         const view = views[key];


### PR DESCRIPTION
### Rational
The release of Hooks allows to avoid classes completely, so it might be reasonable to allow functions to be used as top level components.

### Changes
I've added a check  to make sure `cmp` is a function and since Angular's directives and components are passed as strings it should be safe to attribute that component to React.

[React does similar check internally](https://github.com/facebook/react/blob/769b1f270e1251d9dbdce0fcbd9e92e502d059b8/packages/react-reconciler/src/ReactFiber.js#L302) and `ui-router`'s heuristic with these changes included would be similar. 

@christopherthielen I'd appreciate your feedback on this.