### PR TITLE
fix(UIRouterContextComponent): Handle array of length 1

### DIFF
--- a/src/react/UIRouterReactContext.tsx
+++ b/src/react/UIRouterReactContext.tsx
@@ -62,11 +62,12 @@ export function UIRouterContextComponent(props: {
 
   // We know the AngularJS state. Now render the {children}
   const childrenCount = React.Children.count(children);
+  const isArray = Array.isArray(children);
 
   return (
     <UIRouterContext.Provider value={(inherited && routerFromReactContext) || contextFromAngularJS.router}>
       <UIViewContext.Provider value={(inherited && parentUIViewFromReactContext) || contextFromAngularJS.addr}>
-        {childrenCount === 1 ? React.Children.only(children) : <div>{children}</div>}
+        {childrenCount === 1 && !isArray ? React.Children.only(children) : <div>{children}</div>}
       </UIViewContext.Provider>
     </UIRouterContext.Provider>
   );


### PR DESCRIPTION
Not sure if this is the best way to handle it or if we should just check `React.isValidElement` but when `<UIRouterContextComponent>` is given an array of length=1, it will always throw.

```
<UIRouterContextComponent>
  {[1].map(x => <p>{x}</p>}
</UIRouterContextComponent>
```

This is because `React.Children.count` returns the length of the array and when the array is of length=1, it will use `React.Children.only` which does not allow arrays.